### PR TITLE
Feat : BoardColumn 관련 crud

### DIFF
--- a/src/column/column.controller.ts
+++ b/src/column/column.controller.ts
@@ -6,7 +6,6 @@ import {
   Patch,
   Param,
   Delete,
-  Query,
 } from '@nestjs/common';
 import { ColumnService } from './column.service';
 import { CreateColumnDto } from './dto/create-column.dto';

--- a/src/column/column.controller.ts
+++ b/src/column/column.controller.ts
@@ -6,23 +6,25 @@ import {
   Patch,
   Param,
   Delete,
+  Query,
 } from '@nestjs/common';
 import { ColumnService } from './column.service';
 import { CreateColumnDto } from './dto/create-column.dto';
 import { UpdateColumnDto } from './dto/update-column.dto';
+import { ColumnEntity } from './entities/column.entity';
 
 @Controller('column')
 export class ColumnController {
   constructor(private readonly columnService: ColumnService) {}
 
-  @Post()
-  create(@Body() createColumnDto: CreateColumnDto) {
-    return this.columnService.create(createColumnDto);
+  @Post('create-column')
+  create(@Body() createColumnDto: CreateColumnDto): Promise<ColumnEntity> {
+    return this.columnService.createColumn(createColumnDto);
   }
 
-  @Get()
-  findAll() {
-    return this.columnService.findAll();
+  @Get('get-all/:boardId')
+  findAllColumnsInBoard(@Param('boardId') boardId: number) {
+    return this.columnService.findAllColumnsInBoard(+boardId);
   }
 
   @Get(':id')
@@ -31,12 +33,12 @@ export class ColumnController {
   }
 
   @Patch(':id')
-  update(@Param('id') id: string, @Body() updateColumnDto: UpdateColumnDto) {
-    return this.columnService.update(+id, updateColumnDto);
+  updateColumnName(@Param('id') id: number, @Body() updateColumnDto: UpdateColumnDto) {
+    return this.columnService.updateColumnName(+id, updateColumnDto);
   }
 
   @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.columnService.remove(+id);
+  async removeColumn(@Param('id') id: number) {
+    return this.columnService.removeColumn(+id);
   }
 }

--- a/src/column/column.module.ts
+++ b/src/column/column.module.ts
@@ -1,9 +1,14 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { ColumnService } from './column.service';
 import { ColumnController } from './column.controller';
+import { ColumnEntity } from './entities/column.entity';
+import { Board } from '../board/entities/board.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([ColumnEntity, Board])],
   controllers: [ColumnController],
   providers: [ColumnService],
+  exports: [TypeOrmModule],
 })
 export class ColumnModule {}

--- a/src/column/column.service.ts
+++ b/src/column/column.service.ts
@@ -1,26 +1,83 @@
-import { Injectable } from '@nestjs/common';
 import { CreateColumnDto } from './dto/create-column.dto';
 import { UpdateColumnDto } from './dto/update-column.dto';
-
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ColumnEntity } from './entities/column.entity';
+import { Board } from '../board/entities/board.entity';
 @Injectable()
 export class ColumnService {
-  create(createColumnDto: CreateColumnDto) {
-    return 'This action adds a new column';
+  constructor(
+    @InjectRepository(ColumnEntity)
+    private columnRepository: Repository<ColumnEntity>,
+    @InjectRepository(Board)
+    private boardRepository: Repository<Board>,
+  ) {}
+
+  async createColumn(createColumnDto: CreateColumnDto): Promise<ColumnEntity> {
+    const boardId: bigint = BigInt(createColumnDto.boardId);
+    const board = await this.boardRepository.findOne({
+      where: { id: boardId },
+    });
+
+    if (!board) {
+      throw new NotFoundException('존재하지 않는 보드입니다.');
+    }
+
+    return this.columnRepository.save(createColumnDto);
   }
 
-  findAll() {
-    return `This action returns all column`;
+  async findAllColumnsInBoard(boardId: number): Promise<ColumnEntity[]> {
+    return this.columnRepository.find({
+      where: { boardId: boardId },
+      select: ['boardId', 'name'],
+    });
   }
 
   findOne(id: number) {
-    return `This action returns a #${id} column`;
+    return this.columnRepository.findOne({
+      where: { id: id },
+    });
   }
 
-  update(id: number, updateColumnDto: UpdateColumnDto) {
-    return `This action updates a #${id} column`;
+  async updateColumnName(id: number, updateColumnDto: UpdateColumnDto) {
+    const existingColumn = await this.columnRepository.findOneBy({ id });
+
+    if (!existingColumn) {
+      throw new NotFoundException('존재하지 않는 컬럼입니다.');
+    }
+
+    existingColumn.name = updateColumnDto.name;
+
+    await this.columnRepository.save(existingColumn);
+
+    return {
+      successMessage: '성공적으로 수정하였습니다.',
+      successInfo: {
+        id: existingColumn.id,
+        name: existingColumn.name,
+      },
+    };
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} column`;
+  async removeColumn(id: number) {
+    const existingColumn = await this.columnRepository.findOne({
+      where: { id: id },
+      select: ['id', 'name'],
+    });
+
+    if (!existingColumn) {
+      throw new NotFoundException('존재하지 않는 컬럼입니다.');
+    }
+
+    await this.columnRepository.delete(id);
+
+    return {
+      successMessage: '성공적으로 삭제하였습니다.',
+      successInfo: {
+        id: existingColumn.id,
+        name: existingColumn.name,
+      },
+    };
   }
 }

--- a/src/column/dto/create-column.dto.ts
+++ b/src/column/dto/create-column.dto.ts
@@ -1,1 +1,19 @@
-export class CreateColumnDto {}
+import { IsNumber, IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateColumnDto {
+  /**
+   * 보드 id
+   * @example 1
+   */
+  @IsNumber({}, { message: '보드 지정이 잘못되었습니다.' })
+  @IsNotEmpty({ message: '보드가 지정되지 않았습니다.' })
+  boardId: number;
+
+  /**
+   * 컬럼명
+   * @example "To-Do"
+   */
+  @IsString()
+  @IsNotEmpty({ message: '컬럼명을 입력하세요.' })
+  name: string;
+}

--- a/src/column/dto/update-column-order.dto.ts
+++ b/src/column/dto/update-column-order.dto.ts
@@ -1,11 +1,11 @@
 import { IsString, IsNotEmpty } from 'class-validator';
 
-export class UpdateColumnDto {
+export class UpdateColumnOrderDto {
   /**
    * 컬럼 이름
    * @example "To-Do"
    */
   @IsString()
   @IsNotEmpty()
-  readonly name: string;
+  columnOrder: string;
 }

--- a/src/column/entities/column.entity.ts
+++ b/src/column/entities/column.entity.ts
@@ -11,16 +11,20 @@ import {
 } from 'typeorm';
 import { Board } from '../../board/entities/board.entity';
 import { Task } from '../../task/entities/task.entity';
-@Entity('board_column')
+@Entity('BoardColumn')
 export class ColumnEntity extends BaseEntity {
-  @PrimaryGeneratedColumn()
+  @PrimaryGeneratedColumn({ unsigned: true })
   id: number;
+
   @Column({ type: 'bigint', nullable: false })
   boardId: number;
+
   @Column({ type: 'varchar', length: 255, nullable: false })
   name: string;
+
   @CreateDateColumn({ type: 'datetime', nullable: false })
   createdAt: Date;
+
   @UpdateDateColumn({ type: 'datetime', nullable: false })
   updatedAt: Date;
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 새로운 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### 반영 브랜치
Column -> dev

### 변경 사항
1. column 관련 CRUD 기능 구현
2. column 테이블명 기존 board_column에서 BoardColumn으로 변경

### 테스트 결과
<img width="762" alt="image" src="https://github.com/JY2345/effi-worker/assets/106223763/d022bfb8-6073-4750-b2fe-13f7b5a7ab5f">

한 보드의 컬럼 목록 조회, 한 컬럼 상세조회, 삭제, 이름 수정 모두 정상 동작함
board 부분에서 boardOrder 배열로 저장되도록 수정한 후 컬럼 목록 조회 부분에 해당 배열대로 order by 할 수 있도록 처리하는 로직이 필요함
*수정예정 
